### PR TITLE
fix #48…

### DIFF
--- a/client/jdropit-receive.js
+++ b/client/jdropit-receive.js
@@ -114,6 +114,6 @@ ReceiverHandler.prototype._init = function (isLocal, senderId) {
         that.downloadError("Download failed", "You did not download the file");
     });
     this.socket.on('server_transfer_disconnected', function () {
-        that.downloadError("Download failed", "You did not download the file");
+        that.downloadComplete();
     });
 };

--- a/routes/receiveRouter.ts
+++ b/routes/receiveRouter.ts
@@ -90,7 +90,7 @@ export class ReceiveRouter {
                 const initSize = getNumberOfBytesSent();
                 const sendDate = false;
                 const HEAD_SIZE_WITHOUT_FILE_NAME = sendDate ? 246 : 209;
-                const CHECK_SEND_DELAY_IN_MS = 500;
+                const CHECK_SEND_DELAY_IN_MS = 100;
                 const TIMEOUT_IN_MS = 60 * 1000;
 
 


### PR DESCRIPTION
 by considering that a 'server disconnected' event can only happen when the file is fully transfered but the socket was closed before the server could detect and send the end of file event